### PR TITLE
Fix issue with pod port exposition and add externalIPs

### DIFF
--- a/templates/gitea/_container.tpl
+++ b/templates/gitea/_container.tpl
@@ -18,9 +18,9 @@ Create helm partial for gitea server
       {{- end }}
   ports:
   - name: ssh
-    containerPort: {{ .Values.service.ssh.port  }}
+    containerPort: 22
   - name: http
-    containerPort: {{ .Values.service.http.port  }}
+    containerPort: 3000
   livenessProbe:
     tcpSocket:
       port: http

--- a/templates/gitea/gitea-ssh-svc.yaml
+++ b/templates/gitea/gitea-ssh-svc.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.service.ssh.serviceType }}
+  {{- with .Values.service.ssh.externalIPs }}
+  externalIPs:
+  {{ toYaml . | indent 2 | trim }}
+  {{- end }}
   ports:
   - name: ssh
     port: {{ .Values.service.ssh.port }}

--- a/values.yaml
+++ b/values.yaml
@@ -96,6 +96,7 @@ service:
     ## If serving on a different external port used for determining the ssh url in the gui
     externalPort: 8022
     externalHost: gitea.local
+    externalIPs: []
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Hi,

First of all, nice work !

My pull request contains two things : 

1- It's a problem if the ssh (the same for http) port of the service in the values.yml is used in the same time for the ssh port in the pod :
```
  ssh:
    serviceType: LoadBalancer
    port: 22
```
and :
```
  ports:
  - name: ssh
    containerPort: {{ .Values.service.ssh.port  }}
  - name: http
    containerPort: {{ .Values.service.http.port  }}
  livenessProbe:
```
The port in the pod for ssh is always 22. So if you change the value in the service, you break the pod.

2 - I add the abililty to use externalIPs to expose the service.

Let me know if I have to modify something.
