### PR TITLE
Fixing access to global namespace from within range

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
       - path: {{ default "/" .path }}
         backend:
           serviceName: "{{ template "fullname" $ }}"-http
-          servicePort: {{ .Values.service.http.port }}
+          servicePort: {{ $.Values.service.http.port }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
       paths:
       - path: {{ default "/" .path }}
         backend:
-          serviceName: "{{ template "fullname" $ }}"-http
+          serviceName: "{{ template "fullname" $ }}-http"
           servicePort: {{ $.Values.service.http.port }}
   {{- end }}
   {{- if .Values.ingress.tls }}


### PR DESCRIPTION
To access values from global namespace within a go tpl range statement the `$` is required.