### PR TITLE
Fix multiple hosts variable lookup

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -21,6 +21,14 @@ spec:
       containers:
       {{ include "gitea" . | indent 6 }}
       {{ include "memcached" . | indent 6 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       {{ include "init" . | indent 6 }}
       volumes:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -32,11 +32,11 @@ spec:
       paths:
       - path: {{ default "/" .path }}
         backend:
-          serviceName: "{{ template "fullname" $ }}-http"
-          servicePort: {{ $.Values.service.http.port }}
+          serviceName: {{ template "fullname" . }}-http"
+          servicePort: {{ .Values.service.http.port }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{ toYaml .Values.ingress.tls | indent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Previously specifying multiple hosts would result in a nil pointer evaluating interface {}.service.
This should fix that.

Also added the ability to specify deployment affinity/tolerations